### PR TITLE
Change throw error to console warn

### DIFF
--- a/src/smartbanner.js
+++ b/src/smartbanner.js
@@ -163,7 +163,10 @@ export default class SmartBanner {
 
   publish() {
     if (Object.keys(this.options).length === 0) {
-      throw new Error('No options detected. Please consult documentation.');
+      if (console) {
+        console.warn('smartbanner.js: No options detected. Please consult documentation.');
+      }
+      return false;
     }
 
     if (Bakery.baked) {


### PR DESCRIPTION
Throwing an error is causing an issue that stops all execution when meta tags aren't present. This is creating issues for our testing environment. Warning with a console.warn allows it to fail silently so the app doesn't crash.