### PR TITLE
Enable node 9 in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - 6
   - 7
   - 8
+  - 9
 before_install:
   - rvm install 2.4.0
   - gem install bundler

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "postcss-cli": "^2.4.1"
   },
   "engines": {
-    "node": ">=6.2.0 <9.0.0"
+    "node": ">=6.2.0 <10.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Looks like all tests pass on Node 9, so we can safely enable support for Node 9?