### PR TITLE
Add smartbanner.css to the main in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,10 @@
 {
   "name": "smartbanner.js",
   "description": "Customisable smart app banner for iOS and Android",
-  "main": "dist/smartbanner.js",
+  "main": [
+    "dist/smartbanner.js",
+    "dist/smartbanner.css"
+  ],
   "authors": [
     "Ain Tohvri <ain@flashbit.net>"
   ],


### PR DESCRIPTION
We should add all necessary and main files to (bower.json), so we can get it and use it within gulp or grunt.
Check the [bower.json specifications](https://github.com/bower/spec/blob/master/json.md#main)