### PR TITLE
Update package.json to allow default imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "name": "Ain Tohvri",
     "email": "ain@flashbit.net"
   },
+  "main": "dist/smartbanner.min.js",
+  "style": "dist/smartbanner.min.css",
   "license": "GPL-3.0",
   "bugs": "https://github.com/ain/smartbanner.js/issues",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "name": "Ain Tohvri",
     "email": "ain@flashbit.net"
   },
-  "main": "dist/smartbanner.min.js",
-  "style": "dist/smartbanner.min.css",
+  "main": "dist/smartbanner.js",
+  "style": "dist/smartbanner.css",
   "license": "GPL-3.0",
   "bugs": "https://github.com/ain/smartbanner.js/issues",
   "dependencies": {},


### PR DESCRIPTION
I updated the package.json file to include the following lines:
```
  "main": "dist/smartbanner.min.js",
  "style": "dist/smartbanner.min.css",
```

This now allows you to import the javascript via
```
import smartbanner from 'smartbanner' //es6
var smartbanner = require('smartbanner') //es5
```
and it allows things like postcss to automatically find the styles without any extra configuration
https://github.com/postcss/postcss-import