### PR TITLE
Template markup improvement

### DIFF
--- a/src/smartbanner.js
+++ b/src/smartbanner.js
@@ -133,13 +133,13 @@ export default class SmartBanner {
       <a href="javascript:void();" class="smartbanner__exit js_smartbanner__exit" aria-label="${this.closeLabel}"></a>
       <div class="smartbanner__icon" style="background-image: url(${this.icon});"></div>
       <div class="smartbanner__info">
-        <div>
-          <div class="smartbanner__info__title">${this.options.title}</div>
-          <div class="smartbanner__info__author">${this.options.author}</div>
-          <div class="smartbanner__info__price">${this.options.price}${this.priceSuffix}</div>
+        <div class="smartbanner__copy">
+          <div class="smartbanner__title">${this.options.title}</div>
+          <div class="smartbanner__author">${this.options.author}</div>
+          <div class="smartbanner__price">${this.options.price}${this.priceSuffix}</div>
         </div>
       </div>
-      <a href="${this.buttonUrl}" target="_blank" class="smartbanner__button js_smartbanner__button" rel="noopener" aria-label="${this.options.button}"><span class="smartbanner__button__label">${this.options.button}</span></a>
+      <a href="${this.buttonUrl}" target="_blank" class="smartbanner__button js_smartbanner__button" rel="noopener" aria-label="${this.options.button}"><span class="smartbanner__button-label">${this.options.button}</span></a>
     </div>`;
   }
 

--- a/src/smartbanner.scss
+++ b/src/smartbanner.scss
@@ -82,16 +82,15 @@ $black: #000;
     align-items: center;
 
     color: $black;
+  }
 
-    &__title {
-      font-size: 14px;
-    }
+  &__title {
+    font-size: 14px;
+  }
 
-    &__author,
-    &__price {
-      font-size: 12px;
-    }
-
+  &__author,
+  &__price {
+    font-size: 12px;
   }
 
   &__button {
@@ -112,10 +111,10 @@ $black: #000;
     font-size: 18px;
     text-align: center;
     text-decoration: none;
+  }
 
-    &__label {
-      text-align: center;
-    }
+  &__button-label {
+    text-align: center;
   }
 
   /** Android styles **/
@@ -165,11 +164,11 @@ $black: #000;
     .smartbanner__info {
       color: #ccc;
       text-shadow: 0 1px 2px #000;
+    }
 
-      &__title {
-        color: #fff;
-        font-weight: bold;
-      }
+    .smartbanner__title {
+      color: #fff;
+      font-weight: bold;
     }
 
     .smartbanner__button {
@@ -191,24 +190,24 @@ $black: #000;
       &:hover {
         background: none;
       }
+    }
 
-      &__label {
-        display: block;
-        padding: 0 10px;
+    .smartbanner__button-label {
+      display: block;
+      padding: 0 10px;
 
-        background: #42b6c9;
-        background: linear-gradient(to bottom, #42b6c9, #39a9bb);
-        box-shadow: none;
+      background: #42b6c9;
+      background: linear-gradient(to bottom, #42b6c9, #39a9bb);
+      box-shadow: none;
 
-        line-height: 24px;
-        text-align: center;
-        text-shadow: none;
-        text-transform: none;
+      line-height: 24px;
+      text-align: center;
+      text-shadow: none;
+      text-transform: none;
 
-        &:active,
-        &:hover {
-          background: #2ac7e1;
-        }
+      &:active,
+      &:hover {
+        background: #2ac7e1;
       }
     }
   }

--- a/test/spec/smartbanner_spec.js
+++ b/test/spec/smartbanner_spec.js
@@ -114,52 +114,52 @@ describe('SmartBanner', function() {
       <a href="javascript:void();" class="smartbanner__exit js_smartbanner__exit" aria-label="Close iOS Smart App Banner"></a>
       <div class="smartbanner__icon" style="background-image: url(icon--apple.jpg);"></div>
       <div class="smartbanner__info">
-        <div>
-          <div class="smartbanner__info__title">Smart Application</div>
-          <div class="smartbanner__info__author">SmartBanner Contributors</div>
-          <div class="smartbanner__info__price">FREE - On the App Store</div>
+        <div class="smartbanner__copy">
+          <div class="smartbanner__title">Smart Application</div>
+          <div class="smartbanner__author">SmartBanner Contributors</div>
+          <div class="smartbanner__price">FREE - On the App Store</div>
         </div>
       </div>
-      <a href="https://itunes.apple.com/us/genre/ios/id36?mt=8" target="_blank" class="smartbanner__button js_smartbanner__button" rel="noopener" aria-label="View"><span class="smartbanner__button__label">View</span></a>
+      <a href="https://itunes.apple.com/us/genre/ios/id36?mt=8" target="_blank" class="smartbanner__button js_smartbanner__button" rel="noopener" aria-label="View"><span class="smartbanner__button-label">View</span></a>
     </div>`;
 
   const ANDROID_BODY = `<div class="smartbanner smartbanner--android js_smartbanner">
       <a href="javascript:void();" class="smartbanner__exit js_smartbanner__exit" aria-label="Close Android Smart App Banner"></a>
       <div class="smartbanner__icon" style="background-image: url(icon--google.jpg);"></div>
       <div class="smartbanner__info">
-        <div>
-          <div class="smartbanner__info__title">Smart Application</div>
-          <div class="smartbanner__info__author">SmartBanner Contributors</div>
-          <div class="smartbanner__info__price">FREE - In Google Play</div>
+        <div class="smartbanner__copy">
+          <div class="smartbanner__title">Smart Application</div>
+          <div class="smartbanner__author">SmartBanner Contributors</div>
+          <div class="smartbanner__price">FREE - In Google Play</div>
         </div>
       </div>
-      <a href="https://play.google.com/store" target="_blank" class="smartbanner__button js_smartbanner__button" rel="noopener" aria-label="View"><span class="smartbanner__button__label">View</span></a>
+      <a href="https://play.google.com/store" target="_blank" class="smartbanner__button js_smartbanner__button" rel="noopener" aria-label="View"><span class="smartbanner__button-label">View</span></a>
     </div>`;
 
   const UNDEFINED_BODY = `<div class="smartbanner smartbanner--undefined js_smartbanner">
       <a href="javascript:void();" class="smartbanner__exit js_smartbanner__exit" aria-label="Close Smart App Banner"></a>
       <div class="smartbanner__icon" style="background-image: url(icon--apple.jpg);"></div>
       <div class="smartbanner__info">
-        <div>
-          <div class="smartbanner__info__title">Smart Application</div>
-          <div class="smartbanner__info__author">SmartBanner Contributors</div>
-          <div class="smartbanner__info__price">FREE</div>
+        <div class="smartbanner__copy">
+          <div class="smartbanner__title">Smart Application</div>
+          <div class="smartbanner__author">SmartBanner Contributors</div>
+          <div class="smartbanner__price">FREE</div>
         </div>
       </div>
-      <a href="#" target="_blank" class="smartbanner__button js_smartbanner__button" rel="noopener" aria-label="View"><span class="smartbanner__button__label">View</span></a>
+      <a href="#" target="_blank" class="smartbanner__button js_smartbanner__button" rel="noopener" aria-label="View"><span class="smartbanner__button-label">View</span></a>
     </div>`;
 
   const ANDROID_CUSTOM_DESIGN_BODY = `<div class="smartbanner smartbanner--custom-design js_smartbanner">
       <a href="javascript:void();" class="smartbanner__exit js_smartbanner__exit" aria-label="Close banner"></a>
       <div class="smartbanner__icon" style="background-image: url(icon--google.jpg);"></div>
       <div class="smartbanner__info">
-        <div>
-          <div class="smartbanner__info__title">Smart Application</div>
-          <div class="smartbanner__info__author">SmartBanner Contributors</div>
-          <div class="smartbanner__info__price">FREE - In Google Play</div>
+        <div class="smartbanner__copy">
+          <div class="smartbanner__title">Smart Application</div>
+          <div class="smartbanner__author">SmartBanner Contributors</div>
+          <div class="smartbanner__price">FREE - In Google Play</div>
         </div>
       </div>
-      <a href="https://play.google.com/store" target="_blank" class="smartbanner__button js_smartbanner__button" rel="noopener" aria-label="View"><span class="smartbanner__button__label">View</span></a>
+      <a href="https://play.google.com/store" target="_blank" class="smartbanner__button js_smartbanner__button" rel="noopener" aria-label="View"><span class="smartbanner__button-label">View</span></a>
     </div>`;
 
   const USER_AGENT_IPHONE_IOS8 = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A405 Safari/600.1.4';


### PR DESCRIPTION
Hello! I am glad to see you use BEM for class naming convention (at least, it's pertty similar to bem).

But some parts of html template markup contain few mistakes, if we are talking about BEM.

The first (pretty common, but pretty rude) mistake - is having elements of elements. Or having block's grandchilds, if you like.

E.g. in master branch you have a block called `smartbanner`, which has an element `smartbanner__info`, which in his turn also has an element `smartbanner__info__author`.
[Quick link to FAQ with this question](https://en.bem.info/methodology/faq/#why-not-create-elements-of-elements-block__elem1__elem2).

The second what I noticed - markup has a plain `div` tag without any class. Some will judge you for that, some will not.
But AFAIK, you should avoid tags without a class, every should have one. Because if you dont have a class, there's no information about which block this element belongs to.

I am absolutely not shure about `smartbanner__info-container`, I'm not so inventive, so I would like to accept any suggestion, if you have it.


P.S. If these changes will be approved, I think the can go with v-2.0.0, when it comes to light. Because it might be breaking change for those, who rely on classnames.