### PR TITLE
Add apiready event

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Following events are being dispatched:
 | `smartbanner.view`     | Dispatched when smartbanner is added to display                 |
 | `smartbanner.clickout` | Dispatched when smartbanner is clicked to navigate to app store |
 | `smartbanner.exit`     | Dispatched when smartbanner is closed                           |
+| `smartbanner.apiready` | Dispatched when the smartbanner api has been added to the window|
 
 Example handler (closes smartbanner when user clicks to navigate to app store):
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Following events are being dispatched:
 | `smartbanner.view`     | Dispatched when smartbanner is added to display                 |
 | `smartbanner.clickout` | Dispatched when smartbanner is clicked to navigate to app store |
 | `smartbanner.exit`     | Dispatched when smartbanner is closed                           |
-| `smartbanner.apiready` | Dispatched when the smartbanner api has been added to the window|
+| `smartbanner.init` | Dispatched when the smartbanner has been initialised |
 
 Example handler (closes smartbanner when user clicks to navigate to app store):
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ window.addEventListener('load', function() {
   smartbanner = new SmartBanner();
   if (smartbanner.apiEnabled) {
     window.smartbanner = smartbanner;
+    document.dispatchEvent(new Event('smartbanner.apiready'));
   } else {
     smartbanner.publish();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ window.addEventListener('load', function() {
   smartbanner = new SmartBanner();
   if (smartbanner.apiEnabled) {
     window.smartbanner = smartbanner;
-    document.dispatchEvent(new Event('smartbanner.apiready'));
+    document.dispatchEvent(new Event('smartbanner.init'));
   } else {
     smartbanner.publish();
   }

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -27,6 +27,14 @@ describe('SmartBanner', function() {
     </body>
   </html>`;
 
+  const HTML_API_MODE = `<!doctype html>
+    <html>
+    <head>
+        <meta name="smartbanner:api" content="true">
+    </head>
+    <body></body>
+  </html>`;
+
   const USER_AGENT_IPHONE_IOS9 = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13F69 Safari/601.1';
   const USER_AGENT_IPAD = 'Mozilla/5.0 (iPad; CPU OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13F69 Safari/601.1';
   const USER_AGENT_IPOD = 'Mozilla/5.0 (iPod touch; CPU iPhone OS 8_4_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H321 Safari/600.1.4';
@@ -300,4 +308,89 @@ describe('SmartBanner', function() {
 
   });
 
+  describe('init', function() {
+
+    context('when on iPhone', function() {
+
+      beforeEach(function() {
+        const resourceLoader = new jsdom.ResourceLoader({ userAgent: USER_AGENT_IPHONE_IOS9 });
+        global.window = new JSDOM(HTML_API_MODE, { resources: resourceLoader }).window;
+        global.document = window.document;
+      });
+
+      it('expected to dispatch smartbanner.init event', function(done) {
+        document.addEventListener('smartbanner.init', function () {
+          done();
+        });
+
+        require('../../src/index');
+        // need to delete from node's cache so that it will execute again when it is next required
+        delete require.cache[require.resolve('../../src/index')];
+      });
+
+    });
+
+    context('when on iPad', function() {
+
+      beforeEach(function() {
+        const resourceLoader = new jsdom.ResourceLoader({ userAgent: USER_AGENT_IPAD });
+        global.window = new JSDOM(HTML_API_MODE, { resources: resourceLoader }).window;
+        global.document = window.document;
+      });
+
+      it('expected to dispatch smartbanner.init event', function(done) {
+        document.addEventListener('smartbanner.init', function () {
+          done();
+        });
+
+        require('../../src/index');
+        // need to delete from node's cache so that it will execute again when it is next required
+        delete require.cache[require.resolve('../../src/index')];
+      });
+
+    });
+
+    context('when on iPod', function() {
+
+      beforeEach(function() {
+        const resourceLoader = new jsdom.ResourceLoader({ userAgent: USER_AGENT_IPOD });
+        global.window = new JSDOM(HTML_API_MODE, { resources: resourceLoader }).window;
+        global.document = window.document;
+      });
+
+      it('expected to dispatch smartbanner.init event', function(done) {
+        document.addEventListener('smartbanner.init', function () {
+          done();
+        });
+
+        require('../../src/index');
+        // need to delete from node's cache so that it will execute again when it is next required
+        delete require.cache[require.resolve('../../src/index')];
+      });
+
+    });
+
+    context('when on Android', function() {
+
+      beforeEach(function() {
+        const resourceLoader = new jsdom.ResourceLoader({ userAgent: USER_AGENT_ANDROID });
+        global.window = new JSDOM(HTML_API_MODE, { resources: resourceLoader }).window;
+        global.document = window.document;
+      });
+
+      it('expected to dispatch smartbanner.init event', function(done) {
+        document.addEventListener('smartbanner.init', function () {
+          done();
+        });
+
+        require('../../src/index');
+        // need to delete from node's cache so that it will execute again when it is next required
+        delete require.cache[require.resolve('../../src/index')];
+      });
+
+    });
+
+  });
+
 });
+


### PR DESCRIPTION
Because the smartbanner API object is added to the window in response to the document's "ready" event, I found in my use case the only way to guarantee that I wouldn't be operating on an undefined variable when I come to use it, was to simply check every e.g. 0.1 seconds if it had been added to the window yet. This change broadcasts an event when the API object is ready to use.