### PR TITLE
updates OS check to include newer iPads

### DIFF
--- a/src/detector.js
+++ b/src/detector.js
@@ -1,10 +1,15 @@
 export default class Detector {
 
   static platform() {
-    if (/iPhone|iPad|iPod/i.test(window.navigator.userAgent)) {
-      return 'ios';
-    } else if (/Android/i.test(window.navigator.userAgent)) {
+    let maxTouchPoints = window.navigator.maxTouchPoints;
+    let userAgent = window.navigator.userAgent;
+
+    // if Android, it's Android
+    if (/Android/i.test(userAgent)){
       return 'android';
+    // if not Android and either has maxTouchPoints greater than 0 (newer iPads) or is an older iOS device, it's iOS
+    } else if ((maxTouchPoints && maxTouchPoints > 0) || /iPhone|iPad|iPod/i.test(userAgent)) {
+      return 'ios';
     }
   }
 

--- a/src/detector.js
+++ b/src/detector.js
@@ -4,10 +4,9 @@ export default class Detector {
     let maxTouchPoints = window.navigator.maxTouchPoints;
     let userAgent = window.navigator.userAgent;
 
-    // if Android, it's Android
     if (/Android/i.test(userAgent)){
       return 'android';
-    // if not Android and either has maxTouchPoints greater than 0 (newer iPads) or is an older iOS device, it's iOS
+    // maxTouchPoints is the only effective method to detect iPad iOS 13+
     } else if ((maxTouchPoints && maxTouchPoints > 0) || /iPhone|iPad|iPod/i.test(userAgent)) {
       return 'ios';
     }

--- a/test/spec/detector_spec.js
+++ b/test/spec/detector_spec.js
@@ -14,6 +14,7 @@ describe('Detector', function() {
   const USER_AGENT_IPOD = 'Mozilla/5.0 (iPod touch; CPU iPhone OS 8_4_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H321 Safari/600.1.4';
   const USER_AGENT_ANDROID = 'Mozilla/5.0 (Linux; Android 5.1; XT1039 Build/LPB23.13-17.6; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/79.0.0.18.71;]';
   const USER_AGENT_ANDROID_CUSTOM_WEBAPP = 'Mozilla/5.0 (Linux; Android 5.1; XT1039 Build/LPB23.13-17.6; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/79.0.0.18.71;]  My Example Webapp';
+  const USER_AGENT_IPAD_IOS13 = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15';
 
   const EXCLUDE_USER_AGENT_REGEX = '^.*My Example Webapp$';
   const INCLUDE_USER_AGENT_REGEX = '.*iPhone OS [9\\-10].*';
@@ -92,12 +93,37 @@ describe('Detector', function() {
       });
     });
 
-
     context('when on iPad', function() {
 
       before(function() {
         const resourceLoader = new jsdom.ResourceLoader({ userAgent: USER_AGENT_IPAD });
         global.window = new JSDOM(HTML, { resources: resourceLoader }).window;
+        platform = Detector.platform();
+      });
+
+      it('expected to return ios', function() {
+        expect(platform).to.eql('ios');
+      });
+
+      it('expected exclude regex to not match', function() {
+        expect(Detector.userAgentMatchesRegex(EXCLUDE_USER_AGENT_REGEX)).to.be.false;
+      });
+
+      it('expected include regex to not match', function() {
+        expect(Detector.userAgentMatchesRegex(INCLUDE_USER_AGENT_REGEX)).to.be.false;
+      });
+    });
+
+    context('when on iPad iOS 13 or newer', function() {
+
+      before(function() {
+        const resourceLoader = new jsdom.ResourceLoader({ userAgent: USER_AGENT_IPAD_IOS13 });
+        global.window = new JSDOM(HTML, {
+          resources: resourceLoader,
+          beforeParse(window) {
+            window.navigator.maxTouchPoints = 1;
+          }
+        }).window;
         platform = Detector.platform();
       });
 


### PR DESCRIPTION
Apple changed the userAgent for newer iPads to default to not have "iPad" in the returned value, so the current check sees Safari on new iPads as Mac Desktop Safari. This change would expand the check to include newer iPads based on the window.navigator.maxTouchPoints property. I've tested this on a few of my projects using BrowserStack and it seems to work for both newer and older iPads, as well as continuing to work on Android and iPhones.