### PR TITLE
Alternative condition for enable smartbanner API use.

### DIFF
--- a/src/smartbanner.js
+++ b/src/smartbanner.js
@@ -184,7 +184,7 @@ export default class SmartBanner {
   }
 
   get apiEnabled() {
-    return this.options.api === 'true';
+    return this.options.api === 'true' || this.options.api === 'yes';
   }
 
   get userAgentExcluded() {

--- a/test/spec/smartbanner_spec.js
+++ b/test/spec/smartbanner_spec.js
@@ -73,6 +73,17 @@ describe('SmartBanner', function() {
     </body>
   </html>`;
 
+  // TODO: consider as default in v2
+  const HTML_API_YES = `<!doctype html>
+    <html style="margin-top:10px;">
+    <head>
+      ${HEAD}
+      <meta name="smartbanner:api" content="yes">
+    </head>
+    <body>
+    </body>
+  </html>`;
+
   const HTML_IOS = `<!doctype html>
     <html style="margin-top:10px;">
     <head>
@@ -1172,14 +1183,32 @@ describe('SmartBanner', function() {
 
     context('when API option set', function() {
 
-      before(function() {
-        global.window = new JSDOM(HTML_API, { resources: resourceLoader }).window;
-        global.document = window.document;
-        smartbanner = new SmartBanner();
+      context('with value of "true"', function() {
+
+        before(function() {
+          global.window = new JSDOM(HTML_API, { resources: resourceLoader }).window;
+          global.document = window.document;
+          smartbanner = new SmartBanner();
+        });
+
+        it('expected to return true ', function() {
+          expect(smartbanner.apiEnabled).to.be.true;
+        });
+
       });
 
-      it('expected to return true ', function() {
-        expect(smartbanner.apiEnabled).to.be.true;
+      context('with value of "yes"', function() {
+
+        before(function() {
+          global.window = new JSDOM(HTML_API_YES, { resources: resourceLoader }).window;
+          global.document = window.document;
+          smartbanner = new SmartBanner();
+        });
+
+        it('expected to return true ', function() {
+          expect(smartbanner.apiEnabled).to.be.true;
+        });
+
       });
 
     });


### PR DESCRIPTION
Some frameworks disallow use meta with content "true" string, for Example Nuxt.

It just skit it, see screenshot

<img width="510" alt="image" src="https://github.com/ain/smartbanner.js/assets/4938316/876c3952-799b-410d-be70-4e7ac15e3d88">
